### PR TITLE
Auto-bootstrap dependencies in macOS launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,81 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.5.2] - 2024-05-21
+### Added
+- macOS one-click launcher now auto-creates a project virtual environment,
+  installs dependencies, and remembers the bootstrap step so the app is ready to
+  run after a single double-click.
+
+## [1.5.1] - 2024-05-21
+### Added
+- macOS `.command` launcher that opens the GUI with a single double-click and
+  automatically prefers the project virtual environment when available.
+- Documentation describing the Finder-friendly shortcut so Mac users can start
+  the app without touching the terminal.
+
+## [1.5.0] - 2024-05-21
+### Added
+- Bounding-box overlays with class labels when running model tests so detections
+  are highlighted directly in the preview window.
+- Log summaries that break detections down by class, making it easier to see
+  which objects were found during inference.
+- Helper utilities and unit tests for extracting structured detection metadata
+  from Ultralytics results, plus GUI updates that refresh overlays after each
+  run.
+
+## [1.4.1] - 2024-05-21
+### Added
+- Default YOLOv8 weights alias pre-populated in the GUI so the app launches
+  ready to train or test immediately.
+- Validation helper and documentation updates that recognize common YOLO weight
+  shortcuts, allowing Ultralytics to download them automatically when needed.
+
+## [1.4.0] - 2024-05-21
+### Added
+- Automatic image preview window that opens while browsing and testing sample
+  images so you can see exactly what the model is evaluating.
+- Pillow integration (with graceful fallback) to resize previews and support
+  more image formats when available.
+- Documentation and requirements updates describing the preview workflow and
+  optional dependency.
+
+## [1.3.1] - 2024-05-21
+### Added
+- Detection summaries in the inference log so you can see when no objects were
+  found versus how many were detected.
+- Expanded performance banner metrics that highlight the most recent detection
+  count and how many test images included objects.
+- Helpers and tests for extracting detection counts from both CLI output and
+  ultralytics Python results, plus automatic usage when running the GUI.
+
+## [1.3.0] - 2024-05-21
+### Added
+- Model testing panel with folder selection, navigation controls, and a solve
+  button for running YOLO predictions on individual images.
+- Inference performance tracker that summarizes run counts alongside last,
+  average, and best durations directly in the GUI.
+- Utility helpers and tests for listing supported images and reporting
+  inference metrics.
+- README documentation covering the new evaluation workflow.
+
+## [1.2.1] - 2024-05-21
+### Added
+- Consolidated quick-start command checklist covering virtual environment setup,
+  dependency installation, GUI launch, and running the automated tests.
+
+## [1.2.0] - 2024-05-21
+### Added
+- Scripted shortcut for creating a Python virtual environment before installing dependencies.
+- Documentation updates covering the new helper and activation instructions.
+
+## [1.1.0] - 2024-05-21
+### Added
+- Convenience scripts for installing dependencies and launching the GUI.
+- Application version banner in the window title and a helper to retrieve it programmatically.
+- Documented version history and shortcuts in the README.
+
+## [1.0.0] - 2024-05-21
+### Added
+- Initial release of the YOLO training GUI with CUDA availability indicator and mock configuration helpers.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,165 @@
-# test01
+# YOLO Training GUI
+
+This repository provides a simple Tkinter-based desktop application for
+configuring and launching YOLO training runs. Use it to pick a dataset YAML,
+select pre-trained weights, and start training with a friendly interface.
+
+## Requirements
+
+- Python 3.9+
+- Tkinter (included in most Python distributions)
+- [`ultralytics`](https://pypi.org/project/ultralytics/) package providing the
+  `yolo` command line interface
+- (Optional) [PyTorch](https://pytorch.org/get-started/locally/) with CUDA
+  support if you plan to leverage GPU acceleration
+- (Optional) [`Pillow`](https://pypi.org/project/Pillow/) for high-quality
+  previews of test images and on-screen detection overlays inside the GUI
+
+## Quick command checklist
+
+Follow the commands below if you just want the fastest path from cloning the
+repository to launching the GUI:
+
+```bash
+# 1. (Optional) Create and activate a virtual environment
+./scripts/create_virtualenv.sh
+source .venv/bin/activate
+
+# 2. Install Python dependencies inside that environment
+./scripts/install_dependencies.sh
+
+# 3. Launch the YOLO training GUI
+./scripts/run_gui.sh
+
+# 4. (Optional) Run the automated tests
+python -m unittest discover -s tests
+```
+
+Each command can be executed independently if you only need a specific step.
+
+Optionally create and activate an isolated virtual environment:
+
+```bash
+./scripts/create_virtualenv.sh
+source .venv/bin/activate
+```
+
+> Pass a custom directory name as the first argument if you do not want to use
+> the default `.venv` folder. Set the `PYTHON_BIN` environment variable before
+> running the script to choose a specific Python executable.
+
+Install dependencies with the provided helper script:
+
+```bash
+./scripts/install_dependencies.sh
+```
+
+> The script upgrades `pip` and installs packages listed in
+> [`requirements.txt`](requirements.txt). You can still run `pip install -r
+> requirements.txt` manually if you prefer.
+
+## Usage
+
+Run the GUI application:
+
+```bash
+./scripts/run_gui.sh
+```
+
+> Pass any additional command-line options to `run_gui.sh` and they will be
+> forwarded to `python yolo_gui.py`.
+
+### macOS one-click launcher
+
+If you prefer launching the GUI from Finder, double-click
+[`scripts/run_gui_mac.command`](scripts/run_gui_mac.command). The shortcut
+opens Terminal, prepares a `.venv` environment (creating it on first run),
+installs the dependencies from `requirements.txt`, and then starts
+`yolo_gui.py` for you.
+
+> The initial bootstrap can take a couple of minutes while Python downloads
+> packages. Subsequent launches detect the ready-to-use environment and jump
+> straight to the GUI.
+
+> The `.command` file already has the executable bit set in Git. If you copied it
+> somewhere else manually, run `chmod +x scripts/run_gui_mac.command` once to
+> restore the double-click behaviour.
+
+1. Click **Select** next to "Dataset YAML" to choose your dataset configuration
+   file.
+2. Review the default `yolov8n.pt` weights alias that is pre-filled for you or
+   click **Select** to point to a different pre-trained `.pt` weights file.
+3. Adjust epochs, batch size, image size, project name, and task as needed.
+4. Press **Start Training** to launch the YOLO CLI in the background. Training
+   logs stream into the window. Use **Stop** to terminate the run early.
+5. Use the **Model Testing** panel to pick an image folder for quick
+   predictions. Navigate between files with **← Previous** and **Next →**,
+   then click **Solve** to run inference on the highlighted image. A dedicated
+   preview window keeps the active picture visible while you browse and test.
+6. Review the CUDA status banner above the log area to confirm whether your
+   environment exposes GPU acceleration for PyTorch.
+
+> **Note:** Ensure that the `yolo` executable from the `ultralytics` package is
+> available on your PATH before starting training.
+
+> The GUI understands common YOLOv8 weight aliases (such as `yolov8n.pt`,
+> `yolov8s.pt`, and the `-seg`, `-cls`, or `-pose` variants). When you use one
+> of these shortcuts the Ultralytics tooling downloads the file automatically on
+> first use, so you can begin testing immediately even if the weights are not
+> already on disk.
+
+## GUI Preview
+
+The mock-up below illustrates the layout you will see when launching the
+application, including dataset and weights pickers, hyperparameter fields, and
+training log output.
+
+![YOLO GUI mock-up](assets/yolo_gui_mockup.svg)
+
+## Mock configurations for dry runs
+
+If you want to experiment without launching real training jobs, call
+`generate_mock_training_configs()` from `yolo_gui.py`. By default it returns 30
+distinct `TrainingConfig` objects that simulate different tasks and
+hyperparameters, making it easy to script dry runs or populate demos.
+
+## Model testing workflow
+
+After confirming the weights (the built-in `yolov8n.pt` alias works out of the
+box) you can test the model without leaving the GUI:
+
+1. Click **Select** inside the **Model Testing** panel and point to a folder
+   containing sample images.
+2. Cycle through the images with the navigation buttons to preview filenames
+   and counts. A separate preview window automatically opens to display the
+   highlighted image, resizing it to fit within the window.
+3. Press **Solve** to invoke `yolo mode=predict` on the active image. When
+   Pillow is available, the preview window refreshes with bounding boxes and
+   class labels for every detection so you can visually confirm the results.
+   The log view also reports how long the inference took and summarizes the
+   number of detections per class.
+4. Keep an eye on the performance banner under the buttons to see how many
+   images have been processed, together with the latest, average, and best
+   inference times plus the detection count from the most recent run.
+
+> Close the preview window at any time if you need more space; it will pop back
+> up automatically the next time you navigate to an image or start a new test
+> run.
+
+The app automatically disables navigation buttons when only a single image is
+available and resets the statistics each time you choose a new folder.
+
+## Versioning
+
+Project changes are tracked in [`CHANGELOG.md`](CHANGELOG.md). The GUI window
+title also displays the current version so you can confirm which build is
+running at a glance.
+
+## Testing
+
+Run the unit tests to verify the command-building logic for the training
+configuration helper:
+
+```bash
+python -m unittest discover -s tests
+```

--- a/assets/yolo_gui_mockup.svg
+++ b/assets/yolo_gui_mockup.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="600" viewBox="0 0 960 600">
+  <defs>
+    <style>
+      .title { font: bold 28px 'DejaVu Sans', sans-serif; fill: #1f2933; }
+      .label { font: 18px 'DejaVu Sans', sans-serif; fill: #243b53; }
+      .value { font: 18px 'DejaVu Sans Mono', monospace; fill: #616e7c; }
+      .button { font: bold 20px 'DejaVu Sans', sans-serif; fill: #ffffff; }
+      .checkbox { font: 16px 'DejaVu Sans', sans-serif; fill: #52606d; }
+      .log { font: 16px 'Fira Mono', monospace; fill: #243b53; }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="960" height="600" fill="#f5f7fa"/>
+  <rect x="40" y="40" width="880" height="520" rx="18" fill="#ffffff" stroke="#d9e2ec" stroke-width="2"/>
+  <text x="80" y="100" class="title">YOLO Training Launcher</text>
+
+  <g transform="translate(80, 140)">
+    <text class="label" x="0" y="0">Dataset YAML:</text>
+    <rect x="0" y="20" width="420" height="44" rx="8" fill="#e4ebf5" stroke="#cbd2d9" stroke-width="1"/>
+    <text class="value" x="14" y="48">/data/coco.yaml</text>
+    <rect x="440" y="20" width="120" height="44" rx="8" fill="#334e68"/>
+    <text class="button" x="474" y="50">Browse</text>
+  </g>
+
+  <g transform="translate(80, 230)">
+    <text class="label" x="0" y="0">Pretrained Weights:</text>
+    <rect x="0" y="20" width="420" height="44" rx="8" fill="#e4ebf5" stroke="#cbd2d9" stroke-width="1"/>
+    <text class="value" x="14" y="48">yolov8n.pt</text>
+    <rect x="440" y="20" width="120" height="44" rx="8" fill="#334e68"/>
+    <text class="button" x="474" y="50">Browse</text>
+  </g>
+
+  <g transform="translate(80, 320)">
+    <text class="label" x="0" y="0">Training Hyperparameters</text>
+    <rect x="0" y="20" width="360" height="44" rx="8" fill="#ffffff" stroke="#cbd2d9" stroke-width="1"/>
+    <text class="label" x="20" y="50">Epochs</text>
+    <text class="value" x="120" y="50">100</text>
+    <rect x="380" y="20" width="360" height="44" rx="8" fill="#ffffff" stroke="#cbd2d9" stroke-width="1"/>
+    <text class="label" x="400" y="50">Batch Size</text>
+    <text class="value" x="520" y="50">16</text>
+    <rect x="0" y="84" width="360" height="44" rx="8" fill="#ffffff" stroke="#cbd2d9" stroke-width="1"/>
+    <text class="label" x="20" y="114">Image Size</text>
+    <text class="value" x="140" y="114">640</text>
+    <rect x="380" y="84" width="360" height="44" rx="8" fill="#ffffff" stroke="#cbd2d9" stroke-width="1"/>
+    <text class="label" x="400" y="114">Learning Rate</text>
+    <text class="value" x="580" y="114">0.01</text>
+  </g>
+
+  <g transform="translate(80, 450)">
+    <rect x="0" y="0" width="220" height="54" rx="12" fill="#2bb0ed"/>
+    <text class="button" x="54" y="36">Start Training</text>
+    <rect x="240" y="0" width="180" height="54" rx="12" fill="#d64545"/>
+    <text class="button" x="286" y="36">Stop</text>
+    <g transform="translate(440, 4)">
+      <rect x="0" y="0" width="24" height="24" rx="4" fill="#2bb0ed"/>
+      <text class="checkbox" x="36" y="18">Save logs to file</text>
+    </g>
+  </g>
+
+  <g transform="translate(80, 520)">
+    <text class="label" x="0" y="0">Training Output</text>
+  </g>
+
+  <rect x="80" y="540" width="800" height="0" fill="#ffffff"/>
+  <rect x="80" y="360" width="800" height="140" rx="12" fill="#0b7285" opacity="0.08"/>
+  <rect x="80" y="520" width="800" height="140" rx="12" fill="#ffffff" stroke="#cbd2d9" stroke-width="1"/>
+  <text class="log" x="100" y="560">Epoch 1/100 - mAP@0.5:0.420 - Loss: 4.12</text>
+  <text class="log" x="100" y="590">Epoch 2/100 - mAP@0.5:0.487 - Loss: 3.87</text>
+  <text class="log" x="100" y="620">Epoch 3/100 - mAP@0.5:0.512 - Loss: 3.63</text>
+</svg>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+ultralytics>=8.0.0
+Pillow>=9.0

--- a/scripts/create_virtualenv.sh
+++ b/scripts/create_virtualenv.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PYTHON_BIN=${PYTHON_BIN:-python}
+VENV_DIR=${1:-.venv}
+
+if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
+  echo "${PYTHON_BIN} command not found. Please install Python 3.9+ first." >&2
+  exit 1
+fi
+
+cd "${REPO_ROOT}"
+
+if [ -d "${VENV_DIR}" ]; then
+  echo "Virtual environment directory '${VENV_DIR}' already exists." >&2
+  echo "Activate it with: source ${VENV_DIR}/bin/activate" >&2
+  exit 1
+fi
+
+"${PYTHON_BIN}" -m venv "${VENV_DIR}"
+
+cat <<INFO
+Created virtual environment at '${VENV_DIR}'.
+Activate it with:
+
+  source ${VENV_DIR}/bin/activate
+
+When you're done, deactivate it with:
+
+  deactivate
+INFO

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if ! command -v python >/dev/null 2>&1; then
+  echo "python command not found. Please install Python 3.9+ first." >&2
+  exit 1
+fi
+
+cd "${REPO_ROOT}"
+
+if [ ! -f requirements.txt ]; then
+  echo "requirements.txt not found in ${REPO_ROOT}" >&2
+  exit 1
+fi
+
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt

--- a/scripts/run_gui.sh
+++ b/scripts/run_gui.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if ! command -v python >/dev/null 2>&1; then
+  echo "python command not found. Please install Python 3.9+ first." >&2
+  exit 1
+fi
+
+cd "${REPO_ROOT}"
+
+python yolo_gui.py "$@"

--- a/scripts/run_gui_mac.command
+++ b/scripts/run_gui_mac.command
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -euo pipefail
+
+show_alert() {
+  local title=${1:-"YOLO GUI"}
+  local message=${2:-""}
+
+  if command -v osascript >/dev/null 2>&1; then
+    osascript <<OSA
+display alert "$title" message "$message"
+OSA
+  else
+    >&2 echo "$title: $message"
+  fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+VENV_DIR="${REPO_ROOT}/.venv"
+VENV_PYTHON="${VENV_DIR}/bin/python"
+REQUIREMENTS_FILE="${REPO_ROOT}/requirements.txt"
+BOOTSTRAP_MARKER="${VENV_DIR}/.bootstrap-complete"
+
+ensure_python() {
+  local python_bin=""
+
+  if command -v python3 >/dev/null 2>&1; then
+    python_bin="python3"
+  elif command -v python >/dev/null 2>&1; then
+    python_bin="python"
+  fi
+
+  if [ -z "${python_bin}" ]; then
+    show_alert "Python 3 not found" "Install Python 3.9 or newer, then re-run the launcher."
+    exit 1
+  fi
+
+  echo "${python_bin}"
+}
+
+bootstrap_virtualenv() {
+  local base_python
+  base_python=$(ensure_python)
+
+  if [ ! -x "${VENV_PYTHON}" ]; then
+    "${base_python}" -m venv "${VENV_DIR}"
+  fi
+
+  if [ ! -x "${VENV_PYTHON}" ]; then
+    show_alert "Virtualenv error" "Failed to create a virtual environment in ${VENV_DIR}."
+    exit 1
+  fi
+
+  if [ ! -f "${BOOTSTRAP_MARKER}" ]; then
+    "${VENV_PYTHON}" -m pip install --upgrade pip
+
+    if [ -f "${REQUIREMENTS_FILE}" ]; then
+      "${VENV_PYTHON}" -m pip install -r "${REQUIREMENTS_FILE}"
+    fi
+
+    touch "${BOOTSTRAP_MARKER}"
+  fi
+}
+
+bootstrap_virtualenv
+
+cd "${REPO_ROOT}"
+exec "${VENV_PYTHON}" yolo_gui.py "$@"

--- a/tests/test_training_config.py
+++ b/tests/test_training_config.py
@@ -1,0 +1,279 @@
+import os
+import tempfile
+import unittest
+
+from yolo_gui import (
+    DEFAULT_PRETRAINED_MODEL,
+    DetectedObject,
+    InferenceStats,
+    TrainingConfig,
+    collect_box_detections,
+    count_predictions_from_results,
+    describe_cuda_support,
+    generate_mock_training_configs,
+    get_app_version,
+    is_valid_weight_reference,
+    list_image_files,
+    parse_detection_count,
+)
+
+
+class TrainingConfigTests(unittest.TestCase):
+    def test_build_command_includes_all_parameters(self):
+        config = TrainingConfig(
+            dataset_yaml="data.yaml",
+            model_weights="yolov8n.pt",
+            epochs=50,
+            batch_size=8,
+            image_size=640,
+            project_name="my_project",
+            task="detect",
+        )
+
+        command = config.build_command()
+
+        self.assertIn("yolo", command)
+        self.assertIn("task=detect", command)
+        self.assertIn("mode=train", command)
+        self.assertIn("data=data.yaml", command)
+        self.assertIn("model=yolov8n.pt", command)
+        self.assertIn("epochs=50", command)
+        self.assertIn("batch=8", command)
+        self.assertIn("imgsz=640", command)
+        self.assertIn("project=my_project", command)
+
+    def test_build_command_omits_empty_project(self):
+        config = TrainingConfig(
+            dataset_yaml="data.yaml",
+            model_weights="yolov8n.pt",
+            epochs=50,
+            batch_size=8,
+            image_size=640,
+            project_name="",
+            task="segment",
+        )
+
+        command = config.build_command()
+
+        self.assertNotIn("project=", " ".join(command))
+        self.assertIn("task=segment", command)
+
+
+class DescribeCudaSupportTests(unittest.TestCase):
+    def test_returns_message_when_cuda_not_available(self):
+        class FakeCuda:
+            def is_available(self):
+                return False
+
+        class FakeTorch:
+            cuda = FakeCuda()
+
+        message = describe_cuda_support(FakeTorch())
+
+        self.assertEqual(message, "CUDA Support: Not available")
+
+    def test_returns_device_names_when_available(self):
+        class FakeCuda:
+            def __init__(self):
+                self._names = ["NVIDIA RTX 3090", "NVIDIA RTX 3080"]
+
+            def is_available(self):
+                return True
+
+            def device_count(self):
+                return len(self._names)
+
+            def get_device_name(self, index):
+                return self._names[index]
+
+        class FakeTorch:
+            cuda = FakeCuda()
+
+        message = describe_cuda_support(FakeTorch())
+
+        self.assertIn("CUDA Support: Available", message)
+        self.assertIn("NVIDIA RTX 3080", message)
+
+    def test_returns_message_when_cuda_attribute_missing(self):
+        class FakeTorch:
+            pass
+
+        message = describe_cuda_support(FakeTorch())
+
+        self.assertEqual(message, "CUDA Support: PyTorch without CUDA support")
+
+
+class GenerateMockTrainingConfigsTests(unittest.TestCase):
+    def test_creates_requested_number_of_configs(self):
+        configs = generate_mock_training_configs()
+
+        self.assertEqual(len(configs), 30)
+        self.assertTrue(all(isinstance(cfg, TrainingConfig) for cfg in configs))
+
+    def test_supports_custom_count(self):
+        configs = generate_mock_training_configs(12)
+
+        self.assertEqual(len(configs), 12)
+        self.assertEqual(configs[0].dataset_yaml, "data/mock_dataset_0.yaml")
+        self.assertEqual(configs[-1].project_name, "mock_project_11")
+
+    def test_rejects_non_positive_count(self):
+        with self.assertRaises(ValueError):
+            generate_mock_training_configs(0)
+
+
+class WeightReferenceTests(unittest.TestCase):
+    def test_default_alias_is_valid(self):
+        self.assertTrue(is_valid_weight_reference(DEFAULT_PRETRAINED_MODEL))
+
+    def test_requires_existing_path_for_custom_files(self):
+        self.assertFalse(is_valid_weight_reference("nonexistent/best.pt"))
+        self.assertFalse(is_valid_weight_reference("custom.pt"))
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            weights_path = os.path.join(temp_dir, "best.pt")
+            with open(weights_path, "w", encoding="utf-8") as handle:
+                handle.write("data")
+
+            self.assertTrue(is_valid_weight_reference(weights_path))
+
+
+class VersionTests(unittest.TestCase):
+    def test_version_string_is_not_empty(self):
+        version = get_app_version()
+
+        self.assertIsInstance(version, str)
+        self.assertTrue(version)
+
+
+class InferenceStatsTests(unittest.TestCase):
+    def test_describe_before_any_runs(self):
+        stats = InferenceStats()
+
+        self.assertEqual(stats.describe(), "Performance: No inferences run yet.")
+
+    def test_record_updates_metrics(self):
+        stats = InferenceStats()
+        stats.record(0.5, 3)
+        stats.record(0.2, 0)
+
+        self.assertEqual(stats.total_images, 2)
+        self.assertAlmostEqual(stats.total_time, 0.7)
+        self.assertAlmostEqual(stats.average_duration, 0.35)
+        self.assertEqual(stats.total_detections, 3)
+        self.assertEqual(stats.images_with_detections, 1)
+        self.assertIn("Runs=2", stats.describe())
+        self.assertIn("Best=0.20s", stats.describe())
+        self.assertIn("Detections: 0", stats.describe())
+        self.assertIn("With Objects=1/2", stats.describe())
+
+    def test_negative_duration_treated_as_zero(self):
+        stats = InferenceStats()
+        stats.record(-3.0)
+
+        self.assertEqual(stats.total_images, 1)
+        self.assertEqual(stats.total_time, 0.0)
+        self.assertIn("Last=0.00s", stats.describe())
+        self.assertIn("Detections: Unknown", stats.describe())
+        self.assertIn("With Objects=0/1", stats.describe())
+
+
+class ParseDetectionCountTests(unittest.TestCase):
+    def test_extracts_box_pattern(self):
+        output = "some logs... 5 boxes, Speed: 5.0ms"
+        self.assertEqual(parse_detection_count(output), 5)
+
+    def test_returns_none_when_missing(self):
+        self.assertIsNone(parse_detection_count("no detection info here"))
+
+
+class CountPredictionsFromResultsTests(unittest.TestCase):
+    def test_counts_boxes_and_masks(self):
+        class Boxes(list):
+            pass
+
+        class Masks(list):
+            pass
+
+        class Result:
+            def __init__(self, boxes=None, masks=None):
+                self.boxes = boxes
+                self.masks = masks
+
+        results = [
+            Result(boxes=Boxes([1, 2, 3])),
+            Result(masks=Masks([1, 2])),
+            Result(boxes=Boxes()),
+        ]
+
+        self.assertEqual(count_predictions_from_results(results), 5)
+
+    def test_handles_missing_data(self):
+        class Result:
+            def __init__(self):
+                self.foo = "bar"
+
+        self.assertIsNone(count_predictions_from_results([Result()]))
+
+
+class CollectBoxDetectionsTests(unittest.TestCase):
+    def test_extracts_boxes_with_labels(self):
+        class FakeTensor:
+            def __init__(self, data):
+                self._data = data
+
+            def tolist(self):
+                return self._data
+
+        class FakeBoxes:
+            def __init__(self):
+                self.xyxy = FakeTensor([[0, 1, 2, 3], [10, 11, 12, 13]])
+                self.cls = FakeTensor([0, 1])
+                self.conf = FakeTensor([0.9, 0.5])
+
+        class FakeResult:
+            def __init__(self):
+                self.boxes = FakeBoxes()
+                self.names = {0: "person", 1: "dog"}
+
+        detections = collect_box_detections([FakeResult()])
+
+        self.assertEqual(len(detections), 2)
+        self.assertTrue(all(isinstance(det, DetectedObject) for det in detections))
+        self.assertEqual(detections[0].label, "person")
+        self.assertAlmostEqual(detections[0].xyxy[2], 2.0)
+        self.assertAlmostEqual(detections[1].confidence, 0.5)
+
+    def test_handles_missing_data_gracefully(self):
+        class EmptyResult:
+            def __init__(self):
+                self.names = {}
+
+        self.assertEqual(collect_box_detections([]), [])
+        self.assertEqual(collect_box_detections([EmptyResult()]), [])
+
+
+class ListImageFilesTests(unittest.TestCase):
+    def test_filters_supported_extensions(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            supported = ["image1.jpg", "image2.PNG", "photo.tiff"]
+            unsupported = ["notes.txt", "script.py", "archive.zip"]
+
+            for name in supported + unsupported:
+                path = os.path.join(temp_dir, name)
+                with open(path, "w", encoding="utf-8") as handle:
+                    handle.write("test")
+
+            result = list_image_files(temp_dir)
+
+            expected = [
+                os.path.join(temp_dir, "image1.jpg"),
+                os.path.join(temp_dir, "image2.PNG"),
+                os.path.join(temp_dir, "photo.tiff"),
+            ]
+
+            self.assertEqual(result, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yolo_gui.py
+++ b/yolo_gui.py
@@ -1,0 +1,1205 @@
+"""YOLO training GUI application.
+
+This script provides a simple Tkinter-based GUI for configuring and launching
+YOLO training jobs. Users can pick the dataset YAML file, pre-trained weights
+and adjust training parameters such as the number of epochs, batch size, image
+size and project name. Training is executed in a background thread using the
+`yolo` command line interface, and stdout/stderr from the process is streamed
+into the GUI log window.
+
+Dependencies:
+    * Python 3.9+
+    * Tkinter (included with most Python installations)
+    * The `ultralytics` package that provides the `yolo` CLI.
+
+The GUI focuses on being beginner-friendly for quickly iterating on datasets
+without needing to remember CLI flags.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+import queue
+import re
+import shlex
+import subprocess
+import threading
+import time
+import tkinter as tk
+from collections import Counter
+from dataclasses import dataclass, field
+from tkinter import filedialog, messagebox, ttk
+from typing import Any, Optional
+
+
+APP_VERSION = "1.5.2"
+
+
+DEFAULT_PRETRAINED_MODEL = "yolov8n.pt"
+
+
+KNOWN_WEIGHT_ALIASES = {
+    "yolov8n.pt",
+    "yolov8s.pt",
+    "yolov8m.pt",
+    "yolov8l.pt",
+    "yolov8x.pt",
+    "yolov8n-seg.pt",
+    "yolov8s-seg.pt",
+    "yolov8m-seg.pt",
+    "yolov8l-seg.pt",
+    "yolov8x-seg.pt",
+    "yolov8n-cls.pt",
+    "yolov8s-cls.pt",
+    "yolov8m-cls.pt",
+    "yolov8l-cls.pt",
+    "yolov8x-cls.pt",
+    "yolov8n-pose.pt",
+    "yolov8s-pose.pt",
+    "yolov8m-pose.pt",
+    "yolov8l-pose.pt",
+    "yolov8x-pose.pt",
+}
+
+
+def get_app_version() -> str:
+    """Return the human-readable application version."""
+
+    return APP_VERSION
+
+
+def _load_torch_module() -> Optional[Any]:
+    """Load the torch module if it is installed."""
+
+    if importlib.util.find_spec("torch") is None:
+        return None
+
+    return importlib.import_module("torch")
+
+
+TORCH_MODULE = _load_torch_module()
+
+
+def _load_ultralytics_model_class() -> Optional[Any]:
+    """Return the ``YOLO`` class from ultralytics if the package is installed."""
+
+    spec = importlib.util.find_spec("ultralytics")
+    if spec is None:
+        return None
+
+    module = importlib.import_module("ultralytics")
+    return getattr(module, "YOLO", None)
+
+
+YOLO_MODEL_CLASS = _load_ultralytics_model_class()
+
+
+def _load_pil_components() -> tuple[Optional[Any], Optional[Any], Optional[Any]]:
+    """Return Pillow's ``Image``, ``ImageTk`` and ``ImageDraw`` modules when available."""
+
+    pillow_spec = importlib.util.find_spec("PIL")
+    if pillow_spec is None:
+        return None, None, None
+
+    image_spec = importlib.util.find_spec("PIL.Image")
+    imgtk_spec = importlib.util.find_spec("PIL.ImageTk")
+    draw_spec = importlib.util.find_spec("PIL.ImageDraw")
+
+    if image_spec is None or imgtk_spec is None or draw_spec is None:
+        return None, None, None
+
+    image_module = importlib.import_module("PIL.Image")
+    imgtk_module = importlib.import_module("PIL.ImageTk")
+    draw_module = importlib.import_module("PIL.ImageDraw")
+    return image_module, imgtk_module, draw_module
+
+
+PIL_IMAGE_MODULE, PIL_IMAGETK_MODULE, PIL_IMAGEDRAW_MODULE = _load_pil_components()
+
+
+def describe_cuda_support(torch_module: Optional[Any] = None) -> str:
+    """Return a human-readable description of CUDA availability."""
+
+    module = torch_module if torch_module is not None else TORCH_MODULE
+
+    if module is None:
+        return "CUDA Support: PyTorch not installed"
+
+    try:
+        if not getattr(module, "cuda", None):
+            return "CUDA Support: PyTorch without CUDA support"
+
+        if not module.cuda.is_available():
+            return "CUDA Support: Not available"
+
+        device_count = module.cuda.device_count()
+        if device_count == 0:
+            return "CUDA Support: No CUDA devices detected"
+
+        device_names = {
+            module.cuda.get_device_name(index) for index in range(device_count)
+        }
+        devices_str = ", ".join(sorted(device_names))
+        return f"CUDA Support: Available ({devices_str})"
+    except Exception:
+        return "CUDA Support: Unable to determine"
+
+
+@dataclass
+class TrainingConfig:
+    """Stores YOLO training parameters."""
+
+    dataset_yaml: str
+    model_weights: str
+    epochs: int
+    batch_size: int
+    image_size: int
+    project_name: str
+    task: str = "detect"
+
+    def build_command(self) -> list[str]:
+        """Build the CLI command for the provided configuration."""
+
+        command = [
+            "yolo",
+            f"task={self.task}",
+            "mode=train",
+            f"data={self.dataset_yaml}",
+            f"model={self.model_weights}",
+            f"epochs={self.epochs}",
+            f"batch={self.batch_size}",
+            f"imgsz={self.image_size}",
+        ]
+
+        if self.project_name:
+            command.append(f"project={self.project_name}")
+
+        return command
+
+
+def generate_mock_training_configs(count: int = 30) -> list[TrainingConfig]:
+    """Create a list of mock ``TrainingConfig`` instances for experimentation.
+
+    Parameters
+    ----------
+    count:
+        Number of mock configurations to generate. Defaults to 30.
+
+    Returns
+    -------
+    list[TrainingConfig]
+        Generated configurations cycling through the supported YOLO tasks.
+
+    Raises
+    ------
+    ValueError
+        If ``count`` is not a positive integer.
+    """
+
+    if count <= 0:
+        raise ValueError("count must be a positive integer")
+
+    tasks = ("detect", "segment", "classify", "pose")
+    configs: list[TrainingConfig] = []
+
+    for index in range(count):
+        configs.append(
+            TrainingConfig(
+                dataset_yaml=f"data/mock_dataset_{index}.yaml",
+                model_weights=f"weights/mock_weights_{index}.pt",
+                epochs=10 + index,
+                batch_size=4 + (index % 8),
+                image_size=416 + (index % 5) * 32,
+                project_name=f"mock_project_{index}",
+                task=tasks[index % len(tasks)],
+            )
+        )
+
+    return configs
+
+
+def is_valid_weight_reference(weights_path: str) -> bool:
+    """Return ``True`` when the provided weights path or alias can be used."""
+
+    if not weights_path:
+        return False
+
+    normalized = weights_path.strip()
+    if not normalized:
+        return False
+
+    if os.path.exists(normalized):
+        return True
+
+    if os.path.dirname(normalized):
+        return False
+
+    return normalized in KNOWN_WEIGHT_ALIASES
+
+
+def list_image_files(folder: str) -> list[str]:
+    """Return supported image files inside ``folder`` sorted alphabetically."""
+
+    supported = {".jpg", ".jpeg", ".png", ".bmp", ".gif", ".tif", ".tiff"}
+    files: list[str] = []
+    for entry in sorted(os.listdir(folder)):
+        path = os.path.join(folder, entry)
+        if os.path.isfile(path) and os.path.splitext(path)[1].lower() in supported:
+            files.append(path)
+    return files
+
+
+@dataclass
+class InferenceStats:
+    """Track timing and detection metrics for model inference runs."""
+
+    total_images: int = 0
+    total_time: float = 0.0
+    last_duration: float = 0.0
+    best_duration: float = field(default=float("inf"))
+    total_detections: int = 0
+    last_detections: Optional[int] = None
+    images_with_detections: int = 0
+
+    def record(self, duration: float, detections: Optional[int] = None) -> None:
+        """Record a new inference duration and detection count."""
+
+        safe_duration = max(duration, 0.0)
+        self.total_images += 1
+        self.total_time += safe_duration
+        self.last_duration = safe_duration
+        if safe_duration < self.best_duration:
+            self.best_duration = safe_duration
+
+        if detections is None:
+            self.last_detections = None
+            return
+
+        safe_detections = max(detections, 0)
+        self.last_detections = safe_detections
+        self.total_detections += safe_detections
+        if safe_detections > 0:
+            self.images_with_detections += 1
+
+    @property
+    def average_duration(self) -> float:
+        if self.total_images == 0:
+            return 0.0
+        return self.total_time / self.total_images
+
+    def describe(self) -> str:
+        if self.total_images == 0:
+            return "Performance: No inferences run yet."
+
+        best_value = (
+            f"{self.best_duration:.2f}" if self.best_duration != float("inf") else "-"
+        )
+        detection_summary = "Detections: Unknown"
+        if self.last_detections is not None:
+            detection_summary = f"Detections: {self.last_detections}"
+
+        detected_images = f"With Objects={self.images_with_detections}/{self.total_images}"
+        if self.total_images == 0:
+            detected_images = "With Objects=0/0"
+
+        return (
+            "Performance: "
+            f"Runs={self.total_images} | "
+            f"Last={self.last_duration:.2f}s | "
+            f"Avg={self.average_duration:.2f}s | "
+            f"Best={best_value}s | "
+            f"{detection_summary} | "
+            f"{detected_images}"
+        )
+
+
+@dataclass(frozen=True)
+class DetectedObject:
+    """Bounding box metadata extracted from YOLO inference results."""
+
+    xyxy: tuple[float, float, float, float]
+    label: str
+    confidence: Optional[float] = None
+
+    def formatted_label(self) -> str:
+        if self.confidence is None:
+            return self.label
+        return f"{self.label} ({self.confidence:.2f})"
+
+
+BOUNDING_BOX_COLORS = [
+    "#FF6B6B",
+    "#6BCB77",
+    "#4D96FF",
+    "#FFD93D",
+    "#9B5DE5",
+    "#FF8E00",
+]
+
+
+def _coerce_to_list(value: Any) -> list[Any]:
+    """Best-effort conversion of array-like objects to a Python list."""
+
+    if value is None:
+        return []
+
+    if isinstance(value, list):
+        return value
+
+    if isinstance(value, tuple):
+        return list(value)
+
+    tolist = getattr(value, "tolist", None)
+    if callable(tolist):
+        try:
+            return tolist()
+        except Exception:
+            return []
+
+    try:
+        return list(value)
+    except Exception:
+        return []
+
+
+def collect_box_detections(results: Any) -> list[DetectedObject]:
+    """Extract bounding boxes, labels and confidences from YOLO results."""
+
+    try:
+        iterable = list(results)
+    except TypeError:
+        return []
+
+    if not iterable:
+        return []
+
+    detections: list[DetectedObject] = []
+
+    for result in iterable:
+        boxes = getattr(result, "boxes", None)
+        if boxes is None:
+            continue
+
+        xyxy_values = _coerce_to_list(getattr(boxes, "xyxy", None))
+        cls_values = _coerce_to_list(getattr(boxes, "cls", None))
+        conf_values = _coerce_to_list(getattr(boxes, "conf", None))
+
+        names = getattr(result, "names", None)
+        name_lookup = names if isinstance(names, dict) else {}
+
+        for index, bbox in enumerate(xyxy_values):
+            if not isinstance(bbox, (list, tuple)) or len(bbox) != 4:
+                continue
+
+            cls_idx: Optional[int] = None
+            if index < len(cls_values):
+                try:
+                    cls_idx = int(cls_values[index])
+                except (TypeError, ValueError):
+                    cls_idx = None
+
+            confidence: Optional[float] = None
+            if index < len(conf_values):
+                try:
+                    confidence = float(conf_values[index])
+                except (TypeError, ValueError):
+                    confidence = None
+
+            label = (
+                name_lookup.get(cls_idx, str(cls_idx))
+                if cls_idx is not None
+                else "unknown"
+            )
+
+            detections.append(
+                DetectedObject(
+                    xyxy=(
+                        float(bbox[0]),
+                        float(bbox[1]),
+                        float(bbox[2]),
+                        float(bbox[3]),
+                    ),
+                    label=label,
+                    confidence=confidence,
+                )
+            )
+
+    return detections
+
+
+def parse_detection_count(output: str) -> Optional[int]:
+    """Try to extract the number of detections from CLI output."""
+
+    normalized = output.lower()
+    patterns = (
+        r"boxes=([0-9]+)",
+        r"([0-9]+)\s+boxes",
+        r"detections=([0-9]+)",
+        r"([0-9]+)\s+detections",
+    )
+
+    for pattern in patterns:
+        match = re.search(pattern, normalized)
+        if match:
+            try:
+                return int(match.group(1))
+            except (ValueError, TypeError):
+                continue
+
+    return None
+
+
+def count_predictions_from_results(results: Any) -> Optional[int]:
+    """Estimate the number of predictions returned by ultralytics results."""
+
+    if results is None:
+        return None
+
+    try:
+        iterable = list(results)
+    except TypeError:
+        return None
+
+    if not iterable:
+        return 0
+
+    total = 0
+    has_data = False
+
+    for result in iterable:
+        boxes = getattr(result, "boxes", None)
+        if boxes is not None:
+            try:
+                count = len(boxes)
+            except TypeError:
+                count = len(getattr(boxes, "data", []) or [])
+            total += count
+            has_data = True
+            continue
+
+        masks = getattr(result, "masks", None)
+        if masks is not None:
+            try:
+                total += len(masks)
+            except TypeError:
+                total += len(getattr(masks, "data", []) or [])
+            has_data = True
+            continue
+
+        keypoints = getattr(result, "keypoints", None)
+        if keypoints is not None:
+            try:
+                total += len(keypoints)
+            except TypeError:
+                total += len(getattr(keypoints, "data", []) or [])
+            has_data = True
+            continue
+
+        probs = getattr(result, "probs", None)
+        if probs is not None:
+            has_data = True
+            total += 1
+
+    if not has_data:
+        return None
+
+    return total
+
+
+class YOLOTrainerGUI:
+    """Tkinter application for configuring and launching YOLO training."""
+
+    def __init__(self, root: tk.Tk) -> None:
+        self.root = root
+        self.root.title(f"YOLO Trainer v{get_app_version()}")
+        self.root.geometry("720x620")
+
+        self.log_queue: queue.Queue[str] = queue.Queue()
+        self.training_thread: Optional[threading.Thread] = None
+        self.process: Optional[subprocess.Popen[str]] = None
+        self.inference_thread: Optional[threading.Thread] = None
+
+        self.test_images: list[str] = []
+        self.current_image_index: int = -1
+        self.inference_stats = InferenceStats()
+        self.detections_by_image: dict[str, list[DetectedObject]] = {}
+        self.preview_window: Optional[tk.Toplevel] = None
+        self.preview_label: Optional[tk.Label] = None
+        self._preview_photo: Optional[tk.PhotoImage] = None
+        self._notified_missing_pillow = False
+        self._notified_missing_overlay = False
+
+        self._create_widgets()
+        self._start_log_updater()
+
+        if DEFAULT_PRETRAINED_MODEL in KNOWN_WEIGHT_ALIASES:
+            self._append_log(
+                "Using default YOLO weights alias "
+                f"'{DEFAULT_PRETRAINED_MODEL}'. Select custom weights if needed."
+            )
+
+    def _create_widgets(self) -> None:
+        padding = {"padx": 8, "pady": 4}
+
+        main_frame = ttk.Frame(self.root, padding=10)
+        main_frame.pack(fill=tk.BOTH, expand=True)
+
+        # Dataset selection row
+        dataset_label = ttk.Label(main_frame, text="Dataset YAML:")
+        dataset_label.grid(row=0, column=0, sticky=tk.W, **padding)
+
+        self.dataset_var = tk.StringVar()
+        dataset_entry = ttk.Entry(main_frame, textvariable=self.dataset_var, width=60)
+        dataset_entry.grid(row=0, column=1, sticky=tk.EW, **padding)
+
+        dataset_button = ttk.Button(
+            main_frame, text="Select", command=self._select_dataset
+        )
+        dataset_button.grid(row=0, column=2, sticky=tk.W, **padding)
+
+        # Model weights selection row
+        weights_label = ttk.Label(main_frame, text="Model Weights:")
+        weights_label.grid(row=1, column=0, sticky=tk.W, **padding)
+
+        self.weights_var = tk.StringVar(value=DEFAULT_PRETRAINED_MODEL)
+        weights_entry = ttk.Entry(main_frame, textvariable=self.weights_var, width=60)
+        weights_entry.grid(row=1, column=1, sticky=tk.EW, **padding)
+
+        weights_button = ttk.Button(
+            main_frame, text="Select", command=self._select_weights
+        )
+        weights_button.grid(row=1, column=2, sticky=tk.W, **padding)
+
+        # Training parameters frame
+        params_frame = ttk.LabelFrame(main_frame, text="Training Parameters", padding=10)
+        params_frame.grid(row=2, column=0, columnspan=3, sticky=tk.EW, **padding)
+        params_frame.columnconfigure(1, weight=1)
+
+        self.epochs_var = tk.IntVar(value=100)
+        self.batch_var = tk.IntVar(value=16)
+        self.image_var = tk.IntVar(value=640)
+        self.project_var = tk.StringVar(value="yolo-project")
+        self.task_var = tk.StringVar(value="detect")
+
+        self._add_labeled_entry(params_frame, "Epochs", self.epochs_var, 0)
+        self._add_labeled_entry(params_frame, "Batch Size", self.batch_var, 1)
+        self._add_labeled_entry(params_frame, "Image Size", self.image_var, 2)
+        self._add_labeled_entry(
+            params_frame, "Project Name", self.project_var, 3, entry_type="text"
+        )
+
+        task_label = ttk.Label(params_frame, text="Task")
+        task_label.grid(row=4, column=0, sticky=tk.W, **padding)
+        task_combo = ttk.Combobox(
+            params_frame,
+            textvariable=self.task_var,
+            values=("detect", "segment", "classify", "pose"),
+            state="readonly",
+        )
+        task_combo.grid(row=4, column=1, sticky=tk.EW, **padding)
+
+        # Model testing frame
+        test_frame = ttk.LabelFrame(main_frame, text="Model Testing", padding=10)
+        test_frame.grid(row=3, column=0, columnspan=3, sticky=tk.EW, **padding)
+        test_frame.columnconfigure(1, weight=1)
+
+        test_label = ttk.Label(test_frame, text="Image Folder:")
+        test_label.grid(row=0, column=0, sticky=tk.W, **padding)
+
+        self.test_folder_var = tk.StringVar()
+        test_entry = ttk.Entry(test_frame, textvariable=self.test_folder_var, width=45)
+        test_entry.grid(row=0, column=1, sticky=tk.EW, **padding)
+
+        select_folder_btn = ttk.Button(
+            test_frame, text="Select", command=self._select_test_folder
+        )
+        select_folder_btn.grid(row=0, column=2, sticky=tk.W, **padding)
+
+        self.current_image_var = tk.StringVar(value="No image selected.")
+        current_image_label = ttk.Label(
+            test_frame, textvariable=self.current_image_var, foreground="#555555"
+        )
+        current_image_label.grid(row=1, column=0, columnspan=3, sticky=tk.W, **padding)
+
+        button_container = ttk.Frame(test_frame)
+        button_container.grid(row=2, column=0, columnspan=3, sticky=tk.W, **padding)
+
+        self.prev_button = ttk.Button(
+            button_container,
+            text="← Previous",
+            command=self._show_previous_image,
+            state=tk.DISABLED,
+        )
+        self.prev_button.pack(side=tk.LEFT, padx=4)
+
+        self.solve_button = ttk.Button(
+            button_container,
+            text="Solve",
+            command=self._solve_current_image,
+            state=tk.DISABLED,
+        )
+        self.solve_button.pack(side=tk.LEFT, padx=4)
+
+        self.next_button = ttk.Button(
+            button_container,
+            text="Next →",
+            command=self._show_next_image,
+            state=tk.DISABLED,
+        )
+        self.next_button.pack(side=tk.LEFT, padx=4)
+
+        self.performance_var = tk.StringVar(value=self.inference_stats.describe())
+        performance_label = ttk.Label(test_frame, textvariable=self.performance_var)
+        performance_label.grid(row=3, column=0, columnspan=3, sticky=tk.W, **padding)
+
+        # Control buttons
+        control_frame = ttk.Frame(main_frame)
+        control_frame.grid(row=4, column=0, columnspan=3, sticky=tk.EW, **padding)
+
+        self.start_button = ttk.Button(
+            control_frame, text="Start Training", command=self._start_training
+        )
+        self.start_button.pack(side=tk.LEFT, padx=5)
+
+        stop_button = ttk.Button(control_frame, text="Stop", command=self._stop_training)
+        stop_button.pack(side=tk.LEFT, padx=5)
+
+        # CUDA status information
+        self.cuda_status_var = tk.StringVar(value="CUDA Support: Checking...")
+        cuda_label = ttk.Label(main_frame, textvariable=self.cuda_status_var)
+        cuda_label.grid(row=5, column=0, columnspan=3, sticky=tk.W, **padding)
+
+        self._update_cuda_status()
+
+        # Log output
+        log_label = ttk.Label(main_frame, text="Training Log")
+        log_label.grid(row=6, column=0, columnspan=3, sticky=tk.W, **padding)
+
+        self.log_text = tk.Text(main_frame, height=15, wrap=tk.WORD)
+        self.log_text.grid(row=7, column=0, columnspan=3, sticky=tk.NSEW, **padding)
+
+        scrollbar = ttk.Scrollbar(
+            main_frame, orient=tk.VERTICAL, command=self.log_text.yview
+        )
+        scrollbar.grid(row=7, column=3, sticky=tk.NS)
+        self.log_text.configure(yscrollcommand=scrollbar.set)
+
+        main_frame.columnconfigure(1, weight=1)
+        main_frame.rowconfigure(7, weight=1)
+
+    def _add_labeled_entry(
+        self,
+        frame: ttk.Frame,
+        label_text: str,
+        variable: tk.Variable,
+        row: int,
+        entry_type: str = "int",
+    ) -> None:
+        label = ttk.Label(frame, text=label_text)
+        label.grid(row=row, column=0, sticky=tk.W, padx=5, pady=3)
+
+        if entry_type == "int":
+            entry = ttk.Spinbox(
+                frame,
+                from_=1,
+                to=1000,
+                textvariable=variable,
+                width=10,
+            )
+        else:
+            entry = ttk.Entry(frame, textvariable=variable, width=25)
+
+        entry.grid(row=row, column=1, sticky=tk.W, padx=5, pady=3)
+
+    def _select_dataset(self) -> None:
+        path = filedialog.askopenfilename(
+            title="Select YOLO dataset YAML",
+            filetypes=[("YAML files", "*.yaml *.yml"), ("All files", "*.*")],
+        )
+        if path:
+            self.dataset_var.set(path)
+
+    def _select_weights(self) -> None:
+        path = filedialog.askopenfilename(
+            title="Select YOLO weights (.pt)",
+            filetypes=[("PyTorch weights", "*.pt"), ("All files", "*.*")],
+        )
+        if path:
+            self.weights_var.set(path)
+
+    def _select_test_folder(self) -> None:
+        folder = filedialog.askdirectory(title="Select image folder for testing")
+        if not folder:
+            return
+
+        images = list_image_files(folder)
+        if not images:
+            messagebox.showinfo(
+                "No images found",
+                "The selected folder does not contain any supported image files.",
+            )
+            return
+
+        self.test_folder_var.set(folder)
+        self.test_images = images
+        self.current_image_index = 0
+        self.inference_stats = InferenceStats()
+        self.detections_by_image = {}
+        self._update_performance_label()
+        self._update_test_controls()
+        self._update_current_image_label()
+
+    def _update_test_controls(self) -> None:
+        has_images = bool(self.test_images)
+        nav_state = tk.NORMAL if len(self.test_images) > 1 else tk.DISABLED
+
+        self.solve_button.configure(state=tk.NORMAL if has_images else tk.DISABLED)
+        self.prev_button.configure(state=nav_state)
+        self.next_button.configure(state=nav_state)
+
+    def _ensure_preview_window(self) -> None:
+        if self.preview_window is not None and self.preview_window.winfo_exists():
+            self.preview_window.deiconify()
+            return
+
+        self.preview_window = tk.Toplevel(self.root)
+        self.preview_window.title("Image Preview")
+        self.preview_window.geometry("960x720")
+        self.preview_window.protocol("WM_DELETE_WINDOW", self._on_preview_close)
+
+        self.preview_label = tk.Label(self.preview_window, anchor="center", bg="#202020")
+        self.preview_label.pack(fill=tk.BOTH, expand=True)
+
+    def _on_preview_close(self) -> None:
+        self._close_preview_window()
+
+    def _close_preview_window(self) -> None:
+        if self.preview_window is None:
+            return
+
+        if self.preview_window.winfo_exists():
+            self.preview_window.destroy()
+
+        self.preview_window = None
+        self.preview_label = None
+        self._preview_photo = None
+
+    def _display_current_image(self, image_path: str) -> None:
+        detections = self.detections_by_image.get(image_path)
+        photo = self._create_photo_image(image_path, detections)
+        if photo is None:
+            self._close_preview_window()
+            return
+
+        self._ensure_preview_window()
+        if not self.preview_window or not self.preview_label:
+            return
+
+        self.preview_window.title(f"Image Preview - {os.path.basename(image_path)}")
+        self._preview_photo = photo
+        self.preview_label.configure(image=photo)
+        self.preview_label.image = photo
+
+    def _create_photo_image(
+        self, image_path: str, detections: Optional[list[DetectedObject]]
+    ) -> Optional[tk.PhotoImage]:
+        overlay_requested = bool(detections)
+
+        if (
+            overlay_requested
+            and (
+                PIL_IMAGE_MODULE is None
+                or PIL_IMAGETK_MODULE is None
+                or PIL_IMAGEDRAW_MODULE is None
+            )
+            and not self._notified_missing_overlay
+        ):
+            self._append_log(
+                "Bounding boxes require Pillow. Install Pillow to view detection overlays."
+            )
+            self._notified_missing_overlay = True
+
+        if PIL_IMAGE_MODULE is not None and PIL_IMAGETK_MODULE is not None:
+            try:
+                image = PIL_IMAGE_MODULE.open(image_path).convert("RGB")
+
+                if overlay_requested and detections and PIL_IMAGEDRAW_MODULE is not None:
+                    drawer = PIL_IMAGEDRAW_MODULE.Draw(image)
+                    for detection in detections:
+                        color = BOUNDING_BOX_COLORS[
+                            hash(detection.label) % len(BOUNDING_BOX_COLORS)
+                        ]
+
+                        x1, y1, x2, y2 = detection.xyxy
+                        box_points = [int(x1), int(y1), int(x2), int(y2)]
+                        drawer.rectangle(box_points, outline=color, width=3)
+
+                        label_text = detection.formatted_label()
+                        if label_text:
+                            padding = 4
+                            text_bbox = None
+                            if hasattr(drawer, "textbbox"):
+                                try:
+                                    text_bbox = drawer.textbbox((0, 0), label_text)
+                                except Exception:
+                                    text_bbox = None
+
+                            if text_bbox is not None:
+                                text_width = text_bbox[2] - text_bbox[0]
+                                text_height = text_bbox[3] - text_bbox[1]
+                            else:
+                                try:
+                                    text_width, text_height = drawer.textsize(label_text)
+                                except Exception:
+                                    text_width, text_height = (0, 0)
+
+                            background_top = max(int(y1) - text_height - 2 * padding, 0)
+                            background = [
+                                int(x1),
+                                background_top,
+                                int(x1) + text_width + 2 * padding,
+                                background_top + text_height + 2 * padding,
+                            ]
+                            drawer.rectangle(background, fill=color)
+                            text_position = (
+                                int(x1) + padding,
+                                background_top + padding,
+                            )
+                            try:
+                                drawer.text(text_position, label_text, fill="#000000")
+                            except Exception:
+                                drawer.text(text_position, label_text)
+
+                max_size = (960, 720)
+                resampling_attr = getattr(PIL_IMAGE_MODULE, "Resampling", None)
+                if resampling_attr is not None:
+                    resample = resampling_attr.LANCZOS
+                else:
+                    resample = getattr(PIL_IMAGE_MODULE, "LANCZOS", None)
+                    if resample is None:
+                        resample = getattr(PIL_IMAGE_MODULE, "ANTIALIAS", None)
+
+                if resample is not None:
+                    image.thumbnail(max_size, resample=resample)
+                else:
+                    image.thumbnail(max_size)
+
+                return PIL_IMAGETK_MODULE.PhotoImage(image=image)
+            except Exception as exc:
+                self._append_log(
+                    "Preview error: Pillow could not load "
+                    f"{os.path.basename(image_path)} ({exc}). Falling back to Tkinter loader."
+                )
+
+        if PIL_IMAGE_MODULE is None and not self._notified_missing_pillow:
+            self._append_log(
+                "Install Pillow to enable high-quality previews for additional image formats."
+            )
+            self._notified_missing_pillow = True
+
+        try:
+            return tk.PhotoImage(file=image_path)
+        except Exception as exc:
+            self._append_log(
+                f"Preview error: Unable to display {os.path.basename(image_path)} ({exc})."
+            )
+            return None
+
+    def _update_current_image_label(self) -> None:
+        if not self.test_images or self.current_image_index < 0:
+            self.current_image_var.set("No image selected.")
+            self._close_preview_window()
+            return
+
+        image_path = self.test_images[self.current_image_index]
+        self.current_image_var.set(
+            f"Image {self.current_image_index + 1}/{len(self.test_images)}: {image_path}"
+        )
+        self._display_current_image(image_path)
+
+    def _show_next_image(self) -> None:
+        if not self.test_images:
+            return
+        self.current_image_index = (self.current_image_index + 1) % len(self.test_images)
+        self._update_current_image_label()
+
+    def _show_previous_image(self) -> None:
+        if not self.test_images:
+            return
+        self.current_image_index = (self.current_image_index - 1) % len(self.test_images)
+        self._update_current_image_label()
+
+    def _solve_current_image(self) -> None:
+        if not self.test_images:
+            messagebox.showinfo("Model Testing", "Please select an image folder first.")
+            return
+
+        if self.inference_thread and self.inference_thread.is_alive():
+            messagebox.showinfo(
+                "Model Testing",
+                "Inference is already running. Please wait for it to finish.",
+            )
+            return
+
+        weights_path = self.weights_var.get().strip()
+        if not weights_path:
+            messagebox.showerror(
+                "Model Testing", "Select model weights before running inference."
+            )
+            return
+        if not is_valid_weight_reference(weights_path):
+            messagebox.showerror(
+                "Model Testing", "Model weights path does not exist."
+            )
+            return
+
+        image_path = self.test_images[self.current_image_index]
+        self.detections_by_image.pop(image_path, None)
+        self._display_current_image(image_path)
+        task = self.task_var.get().strip() or "detect"
+
+        command = [
+            "yolo",
+            f"task={task}",
+            "mode=predict",
+            f"model={weights_path}",
+            f"source={image_path}",
+            "save=False",
+        ]
+
+        self._append_log(
+            "Starting inference with command:\n" f"{shlex.join(command)}\n"
+        )
+
+        def run_inference() -> None:
+            detection_count: Optional[int] = None
+            start_time = time.perf_counter()
+
+            try:
+                if YOLO_MODEL_CLASS is not None:
+                    try:
+                        model = YOLO_MODEL_CLASS(weights_path)
+                        results = model.predict(image_path, verbose=False)
+                        duration = time.perf_counter() - start_time
+                        detection_count = count_predictions_from_results(results)
+                        detection_boxes = collect_box_detections(results)
+                        if detection_count is None:
+                            detection_count = len(detection_boxes)
+                        self.detections_by_image[image_path] = detection_boxes
+                        self.root.after(
+                            0, lambda path=image_path: self._display_current_image(path)
+                        )
+                        self.inference_stats.record(duration, detection_count)
+                        self.log_queue.put(
+                            f"Inference completed in {duration:.2f}s for {os.path.basename(image_path)}."
+                        )
+                        self._log_detection_summary(detection_count, detection_boxes)
+                        return
+                    except Exception as exc:
+                        self.log_queue.put(
+                            f"Python inference failed ({exc}). Falling back to CLI execution."
+                        )
+                        start_time = time.perf_counter()
+
+                result = subprocess.run(
+                    command,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    check=False,
+                )
+                duration = time.perf_counter() - start_time
+                self.detections_by_image.pop(image_path, None)
+                if result.stdout:
+                    for line in result.stdout.splitlines():
+                        self.log_queue.put(line)
+                    detection_count = parse_detection_count(result.stdout)
+
+                if result.returncode == 0:
+                    self.inference_stats.record(duration, detection_count)
+                    self.log_queue.put(
+                        f"Inference completed in {duration:.2f}s for {os.path.basename(image_path)}."
+                    )
+                    self._log_detection_summary(detection_count, None)
+                else:
+                    self.log_queue.put(
+                        f"Inference failed with exit code {result.returncode}."
+                    )
+            except FileNotFoundError:
+                self.log_queue.put(
+                    "The 'yolo' command was not found. Install ultralytics and ensure it is on your PATH."
+                )
+            except Exception as exc:
+                self.log_queue.put(f"An unexpected inference error occurred: {exc}")
+            finally:
+                self.inference_thread = None
+                self.root.after(0, self._update_performance_label)
+
+        self.inference_thread = threading.Thread(target=run_inference, daemon=True)
+        self.inference_thread.start()
+
+    def _update_performance_label(self) -> None:
+        self.performance_var.set(self.inference_stats.describe())
+
+    def _log_detection_summary(
+        self,
+        detection_count: Optional[int],
+        detections: Optional[list[DetectedObject]],
+    ) -> None:
+        if detection_count is None:
+            self.log_queue.put(
+                "Detections: Unable to determine. Review the output above for details."
+            )
+            return
+
+        if detection_count == 0:
+            self.log_queue.put("Detections: 0 (no objects detected).")
+        elif detection_count == 1:
+            self.log_queue.put("Detections: 1 object detected.")
+        else:
+            self.log_queue.put(f"Detections: {detection_count} objects detected.")
+
+        if not detections:
+            return
+
+        class_counts = Counter(det.label for det in detections)
+        if not class_counts:
+            return
+
+        breakdown = ", ".join(
+            f"{label}: {class_counts[label]}" for label in sorted(class_counts)
+        )
+        self.log_queue.put(f"Detected classes → {breakdown}")
+
+    def _validate_config(self) -> Optional[TrainingConfig]:
+        dataset_yaml = self.dataset_var.get().strip()
+        model_weights = self.weights_var.get().strip()
+
+        if not dataset_yaml:
+            messagebox.showerror("Validation Error", "Please select a dataset YAML file.")
+            return None
+        if not os.path.exists(dataset_yaml):
+            messagebox.showerror("Validation Error", "Dataset YAML path does not exist.")
+            return None
+
+        if not model_weights:
+            messagebox.showerror("Validation Error", "Please select model weights (.pt).")
+            return None
+        if not is_valid_weight_reference(model_weights):
+            messagebox.showerror("Validation Error", "Model weights path does not exist.")
+            return None
+
+        try:
+            epochs = int(self.epochs_var.get())
+            batch_size = int(self.batch_var.get())
+            image_size = int(self.image_var.get())
+        except (ValueError, tk.TclError):
+            messagebox.showerror("Validation Error", "Epoch, batch and image size must be integers.")
+            return None
+
+        if epochs <= 0 or batch_size <= 0 or image_size <= 0:
+            messagebox.showerror(
+                "Validation Error", "Epochs, batch size and image size must be positive."
+            )
+            return None
+
+        project_name = self.project_var.get().strip()
+        task = self.task_var.get().strip() or "detect"
+
+        return TrainingConfig(
+            dataset_yaml=dataset_yaml,
+            model_weights=model_weights,
+            epochs=epochs,
+            batch_size=batch_size,
+            image_size=image_size,
+            project_name=project_name,
+            task=task,
+        )
+
+    def _start_training(self) -> None:
+        if self.training_thread and self.training_thread.is_alive():
+            messagebox.showinfo("Training", "A training process is already running.")
+            return
+
+        config = self._validate_config()
+        if not config:
+            return
+
+        command = config.build_command()
+        self._append_log(
+            f"Starting training with command:\n{shlex.join(command)}\n"
+        )
+
+        self.start_button.state(["disabled"])
+
+        def run_training() -> None:
+            try:
+                self.process = subprocess.Popen(
+                    command,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    bufsize=1,
+                )
+
+                assert self.process.stdout is not None
+                for line in self.process.stdout:
+                    self.log_queue.put(line.rstrip())
+                return_code = self.process.wait()
+                if return_code == 0:
+                    self.log_queue.put("Training completed successfully.")
+                else:
+                    self.log_queue.put(f"Training failed with exit code {return_code}.")
+            except FileNotFoundError:
+                self.log_queue.put(
+                    "The 'yolo' command was not found. Install ultralytics with "
+                    "`pip install ultralytics` and ensure it is on your PATH."
+                )
+            except Exception as exc:
+                self.log_queue.put(f"An unexpected error occurred: {exc}")
+            finally:
+                self.process = None
+                self.training_thread = None
+                self.root.after(0, lambda: self.start_button.state(["!disabled"]))
+
+        self.training_thread = threading.Thread(target=run_training, daemon=True)
+        self.training_thread.start()
+
+    def _stop_training(self) -> None:
+        if self.process and self.process.poll() is None:
+            self.process.terminate()
+            self._append_log("Stop signal sent to training process.")
+        else:
+            messagebox.showinfo("Training", "No training process is currently running.")
+
+    def _append_log(self, message: str) -> None:
+        self.log_text.insert(tk.END, message + "\n")
+        self.log_text.see(tk.END)
+
+    def _start_log_updater(self) -> None:
+        def poll_queue() -> None:
+            while True:
+                try:
+                    line = self.log_queue.get_nowait()
+                except queue.Empty:
+                    break
+                else:
+                    self._append_log(line)
+            self.root.after(200, poll_queue)
+
+        poll_queue()
+
+    def _update_cuda_status(self) -> None:
+        self.cuda_status_var.set(describe_cuda_support())
+
+
+def main() -> None:
+    root = tk.Tk()
+    app = YOLOTrainerGUI(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- teach the macOS one-click launcher to create a virtual environment, install requirements, and surface friendly alerts when setup fails
- document the automated bootstrap workflow and bump the GUI version to 1.5.2
- record the new release in the changelog

## Testing
- python -m compileall yolo_gui.py
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68e4f0cecac08324985aece79aae6fd5