### PR TITLE
Improve image preview resizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 - macOS one-click launcher now auto-creates a project virtual environment,
   installs dependencies, and remembers the bootstrap step so the app is ready to
   run after a single double-click.
+### Changed
+- Image preview window now scales images proportionally when resized so aspect
+  ratios are preserved even in smaller layouts.
 
 ## [1.5.1] - 2024-05-21
 ### Added


### PR DESCRIPTION
## Summary
- keep the preview window responsive by caching the original image and regenerating scaled photos when the window size changes
- note the proportional scaling behaviour in the changelog

## Testing
- python -m py_compile yolo_gui.py

------
https://chatgpt.com/codex/tasks/task_e_68e538f6cea483249390919977870236